### PR TITLE
move setControlEncoding to configureClient() otherwise control encoding ...

### DIFF
--- a/core/src/main/java/org/apache/commons/vfs2/provider/ftp/FTPClientWrapper.java
+++ b/core/src/main/java/org/apache/commons/vfs2/provider/ftp/FTPClientWrapper.java
@@ -130,9 +130,15 @@ class FTPClientWrapper implements FtpClient
     private FTPFile[] listFilesInDirectory(String relPath) throws IOException
     {
         FTPFile[] files;
-
+				// escape Space with backslach on unix like ftp
+				String listPath = relPath;
+			  String strSysType = getFtpClient().getSystemType();
+				if ( listPath != null && strSysType.contains(FTPClientConfig.SYST_UNIX) ) {
+					if ( listPath.contains(" ") )
+						listPath = listPath.replaceAll(" ", "\\\\ ");
+				}
         // VFS-307: no check if we can simply list the files, this might fail if there are spaces in the path
-        files = getFtpClient().listFiles(relPath);
+        files = getFtpClient().listFiles(listPath);
         if (FTPReply.isPositiveCompletion(getFtpClient().getReplyCode()))
         {
             return files;
@@ -145,7 +151,7 @@ class FTPClientWrapper implements FtpClient
         if (relPath != null)
         {
             workingDirectory = getFtpClient().printWorkingDirectory();
-            if (!getFtpClient().changeWorkingDirectory(relPath))
+            if (!getFtpClient().changeWorkingDirectory(listPath))
             {
                 return null;
             }

--- a/core/src/main/java/org/apache/commons/vfs2/provider/ftp/FtpClientFactory.java
+++ b/core/src/main/java/org/apache/commons/vfs2/provider/ftp/FtpClientFactory.java
@@ -137,11 +137,6 @@ public final class FtpClientFactory
                     client.enterLocalPassiveMode();
                 }
 
-                String controlEncoding = FtpFileSystemConfigBuilder.getInstance().getControlEncoding(fileSystemOptions);
-                if (controlEncoding != null)
-                {
-                    client.setControlEncoding(controlEncoding);
-                }
             }
             catch (final IOException e)
             {
@@ -209,5 +204,11 @@ public final class FtpClientFactory
 
             client.configure(config);
         }
+
+				String controlEncoding = FtpFileSystemConfigBuilder.getInstance().getControlEncoding(fileSystemOptions);
+				if (controlEncoding != null)
+				{
+						client.setControlEncoding(controlEncoding);
+				}
     }
 }


### PR DESCRIPTION
move setControlEncoding to configureClient() otherwise control encoding is never applyed ( must be set before FtpClient.connect() ).

Socket and Parser is created on first FtpClient.connect(); so the control encoding must be set before that call
